### PR TITLE
[fix] 세로 모드 고정

### DIFF
--- a/Weatherman/Weatherman/AppDelegate.swift
+++ b/Weatherman/Weatherman/AppDelegate.swift
@@ -17,6 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return true
   }
 
+  // 세로 모드 고정
+  func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    return UIInterfaceOrientationMask.portrait
+  }
+
   // MARK: UISceneSession Lifecycle
 
   func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {


### PR DESCRIPTION
두 번째 화면에서 스크롤뷰 없이 스택뷰로만 구현했기 때문에 
가로 모드로 전환하면 뷰가 잘리는 현상 발생 -> 세로 모드로만 고정